### PR TITLE
Bump versions, drop sample builds other than 2.12/2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ script:
  - sbt +update
  - cd -
  - cd maven-sample
- - mvn -Pscala-2.10 clean compile package
- - mvn -Pscala-2.10 exec:java -Dexec.mainClass=XMLHelloWorld
- - mvn -Pscala-2.11 clean compile package
- - mvn -Pscala-2.11 exec:java -Dexec.mainClass=XMLHelloWorld
  - mvn -Pscala-2.12 clean compile package
  - mvn -Pscala-2.12 exec:java -Dexec.mainClass=XMLHelloWorld
+ - mvn -Pscala-2.13 clean compile package
+ - mvn -Pscala-2.13 exec:java -Dexec.mainClass=XMLHelloWorld
 
 cache:
   directories:

--- a/maven-sample/pom.xml
+++ b/maven-sample/pom.xml
@@ -7,90 +7,56 @@
   <properties>
     <encoding>UTF-8</encoding>
   </properties>
-  <!-- Maven profiles allow you to support both Scala 2.10, 2.11 and Scala 2.12 with
-    the right dependencies for modules specified for each version separately -->
+  <!-- Maven profiles allow you to support both Scala 2.12 and Scala 2.13.
+       If you require different versions of a dependency contigent on the Scala
+       version, define additional properties in these profiles and refer to them
+       from the `<dependencies>` section below.
+    -->
   <profiles>
     <profile>
-      <id>scala-2.12</id>
+      <id>scala-2.13</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <scala.version>2.12.7</scala.version>
+        <scala.version>2.13.3</scala.version>
+        <scala.compat.version>2.13</scala.compat.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>scala-2.12</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <scala.version>2.12.11</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
       </properties>
-      <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_${scala.compat.version}</artifactId>
-            <version>1.1.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-            <version>1.1.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-swing_${scala.compat.version}</artifactId>
-            <version>2.0.3</version>
-          </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>scala-2.11</id>
-      <properties>
-        <scala.version>2.11.12</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
-      </properties>
-      <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_${scala.compat.version}</artifactId>
-            <version>1.1.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-            <version>1.1.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-swing_${scala.compat.version}</artifactId>
-            <version>1.0.2</version>
-          </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>scala-2.10</id>
-      <properties>
-        <scala.version>2.10.7</scala.version>
-        <scala.compat.version>2.10</scala.compat.version>
-      </properties>
-      <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-swing</artifactId>
-            <version>${scala.version}</version>
-          </dependency>
-      </dependencies>
     </profile>
   </profiles>
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_${scala.compat.version}</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-swing_${scala.compat.version}</artifactId>
+      <version>2.1.1</version>
+    </dependency>
+  </dependencies>
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>
     <testSourceDirectory>src/test/scala</testSourceDirectory>
@@ -98,12 +64,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
       </plugin>
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>4.4.0</version>
         <executions>
           <execution>
             <goals>
@@ -114,7 +80,8 @@
         </executions>
         <configuration>
           <args>
-            <!-- work-around for https://issues.scala-lang.org/browse/SI-8358 -->
+            <arg>-deprecation</arg>
+            <!-- work-around for https://github.com/scala/bug/issues/8358 -->
             <arg>-nobootcp</arg>
           </args>
         </configuration>

--- a/sbt-sample/build.sbt
+++ b/sbt-sample/build.sbt
@@ -4,28 +4,14 @@ organization := "sample"
 
 version := "1.0"
 
-crossScalaVersions := Seq("2.12.7", "2.11.12", "2.10.7")
+crossScalaVersions := Seq("2.13.3", "2.12.11")
 
-scalaVersion := "2.12.7"
+scalaVersion := "2.13.3"
 
-// add dependencies on standard Scala modules, in a way
-// supporting cross-version publishing
-// taken from: http://github.com/scala/scala-module-dependency-sample
-libraryDependencies := {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    // if Scala 2.12+ is used, use scala-swing 2.x
-    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
-      libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
-        "org.scala-lang.modules" %% "scala-swing" % "2.0.3")
-    case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-      libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
-        "org.scala-lang.modules" %% "scala-swing" % "1.0.2")
-    case _ =>
-      // or just libraryDependencies.value if you don't depend on scala-swing
-      libraryDependencies.value :+ "org.scala-lang" % "scala-swing" % scalaVersion.value
-  }
-}
+libraryDependencies ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
+  "org.scala-lang.modules" %% "scala-swing" % "2.1.1"
+)
+
+scalacOptions += "-deprecation"

--- a/sbt-sample/project/build.properties
+++ b/sbt-sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.13


### PR DESCRIPTION
Also:

  - demonstrate how to add `-deprecation`
  - simplify the dependency version selection, the sample
    seemed to have lots of complexity related to cross-building
    across 2.10-2.11